### PR TITLE
Add asChild prop to ButtonProps

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -33,7 +33,9 @@ const buttonVariants = cva(
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {}
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- add optional `asChild` prop to `ButtonProps`

## Testing
- `pnpm lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685f5c4ac0008329a1cc7f5a86c011bd